### PR TITLE
Fix: Correctly parse multi-line JSON response for keywords

### DIFF
--- a/app/cron/fetch_news.php
+++ b/app/cron/fetch_news.php
@@ -74,7 +74,8 @@ try {
 
     if ($rawKeywordsResponse) {
         // Attempt to find JSON array within the response, as AI might add extra text
-        if (preg_match('/\[.*\]/', $rawKeywordsResponse, $matches)) {
+        // Added 's' modifier to make dot match newlines, as AI response might be multi-line.
+        if (preg_match('/\[.*\]/s', $rawKeywordsResponse, $matches)) {
             $jsonResponse = $matches[0];
             $decodedKeywords = json_decode($jsonResponse, true);
             if (json_last_error() === JSON_ERROR_NONE && is_array($decodedKeywords)) {


### PR DESCRIPTION
The AI response for keywords can be a multi-line JSON string. The previous regex `/\[.*\]/` failed to match this because the dot metacharacter did not match newlines by default.

This commit adds the 's' (dotall) modifier to the regex, making it `/\[.*\]/s`. This allows the dot to match newline characters, ensuring the entire JSON array is captured and parsed correctly.